### PR TITLE
Fix Broken Link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For more details read about [Jekyll][1] on its web page.
 
 # Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/pietromenn/jekyll-architect-theme.
+Bug reports and pull requests are welcome on GitHub at https://github.com/pietromenna/jekyll-architect-theme.
 
 # Development
 


### PR DESCRIPTION
Repo link was missing an "`a`" in username:

`https://github.com/pietromenn/` =>`https://github.com/pietromenna/`